### PR TITLE
Update level1.rst

### DIFF
--- a/doc/level1.rst
+++ b/doc/level1.rst
@@ -567,7 +567,7 @@ __________________________
 
 If ``public_key`` is ``null``, then set
 ``target-keys[to-addr]`` to ``gossip_key`` and set
-``preliminary-recommendation`` to ``discourage`` and skip to the
+``ui-recommendation`` to ``discourage`` and skip to the
 :ref:`final-recommendation-phase`.
 
 Otherwise, set ``target-keys[to-addr]`` to ``public_key``.


### PR DESCRIPTION
Using gossip_key should end in an ui-recommendation?


Currently 

> If public_key is null, then set target-keys[to-addr] to gossip_key and set
preliminary-recommendation to discourage and skip to the Deciding to Encrypt by Default
(page 9).

ends in `preliminary-recommendation`.
This `preliminary-recommendation` will never used as `Deciding to Encrypt by Default` is skipped.

So would be `ui-recommendation` the correct result?